### PR TITLE
allow dragging cells off the bottom of table

### DIFF
--- a/Cities.xcodeproj/project.pbxproj
+++ b/Cities.xcodeproj/project.pbxproj
@@ -184,6 +184,8 @@
 		4B65C30B1AC3A5740053DA33 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0710;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Soheil Moayedi Azarpour";
 				TargetAttributes = {

--- a/Cities.xcodeproj/project.pbxproj
+++ b/Cities.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Soheil Moayedi Azarpour";
 				TargetAttributes = {
 					4B65C3121AC3A5740053DA33 = {
@@ -310,6 +310,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -378,6 +379,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Cities/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -388,6 +390,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Cities/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -406,6 +409,7 @@
 				);
 				INFOPLIST_FILE = CitiesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cities.app/Cities";
 			};
@@ -421,6 +425,7 @@
 				);
 				INFOPLIST_FILE = CitiesTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cities.app/Cities";
 			};

--- a/Cities/CitiesTableViewController.swift
+++ b/Cities/CitiesTableViewController.swift
@@ -94,9 +94,11 @@ class CitiesTableViewController: UITableViewController {
   func longPressGestureRecognized(gesture: UILongPressGestureRecognizer) {
     let state: UIGestureRecognizerState = gesture.state;
     let location: CGPoint = gesture.locationInView(tableView)
-    let indexPath: NSIndexPath? = tableView.indexPathForRowAtPoint(location)
+    var indexPath: NSIndexPath? = tableView.indexPathForRowAtPoint(location)
+    
+    // if indexPath is null, that means we took our dragged cell off the bottom of the table
     if indexPath == nil {
-      return
+        indexPath = NSIndexPath(forRow: cities.count - 1, inSection: 0)
     }
     
     switch (state) {

--- a/Cities/CitiesTableViewController.swift
+++ b/Cities/CitiesTableViewController.swift
@@ -80,14 +80,14 @@ class CitiesTableViewController: UITableViewController {
   }
   
   override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCellWithIdentifier("CityInformationCellIdentifier") as! UITableViewCell
+    let cell = tableView.dequeueReusableCellWithIdentifier("CityInformationCellIdentifier", forIndexPath: indexPath)
     
     let city: City = cities[indexPath.row] as! City
     let census = city.censuses[selectedYear.rawValue]
     cell.textLabel?.text = city.name
     cell.detailTextLabel?.text = census.formattedPopulation
     return cell
-  }
+}
   
   // MARK: UIGestureRecognizer
   
@@ -161,7 +161,10 @@ class CitiesTableViewController: UITableViewController {
     
     // Make an image from the input view.
     UIGraphicsBeginImageContextWithOptions(inputView.bounds.size, false, 0)
-    inputView.layer.renderInContext(UIGraphicsGetCurrentContext())
+    if let context = UIGraphicsGetCurrentContext()
+    {
+        inputView.layer.renderInContext(context)
+    }
     let image = UIGraphicsGetImageFromCurrentImageContext()
     UIGraphicsEndImageContext();
     

--- a/Cities/CitiesTableViewController.swift
+++ b/Cities/CitiesTableViewController.swift
@@ -87,7 +87,7 @@ class CitiesTableViewController: UITableViewController {
     cell.textLabel?.text = city.name
     cell.detailTextLabel?.text = census.formattedPopulation
     return cell
-}
+  }
   
   // MARK: UIGestureRecognizer
   

--- a/Cities/Data Access Layer/CitiesManager.swift
+++ b/Cities/Data Access Layer/CitiesManager.swift
@@ -57,7 +57,7 @@ class CitiesManager {
     let citiesData = NSArray(contentsOfURL: dataURL)
     
     var cities: Array<City> = []
-    citiesData?.enumerateObjectsUsingBlock({ (cityData: AnyObject!, index: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
+    citiesData?.enumerateObjectsUsingBlock({ (cityData: AnyObject, index: Int, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
       let city = City()
       if cityData is NSDictionary {
         let dictionary = cityData as! NSDictionary

--- a/Cities/Info.plist
+++ b/Cities/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/CitiesTests/Info.plist
+++ b/CitiesTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>azarpour.soheil.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Cities
-A sample project written in Swift 1.2
+A sample project written in Swift 2.0
 Move `UITableViewCell` with `UILongPressGestureRecognizer`.


### PR DESCRIPTION
This pull request not only brings in the Swift 2 changes, but also fixes a bug in the code where a cell dragged off the bottom of the table would seemingly _freeze_ the drag.  

The change now allows the cell to end up in the last position in the table.
